### PR TITLE
Implement UDP

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import sys
 import glob
@@ -8,12 +9,12 @@ if len(sys.argv) == 2:
 else:
     version = int(input('var version: '))
 
-cslistName = 'ADD_ME.cslist'
+cslistName = 'ToySerialController.cslist'
 varName = 'Yoooi.ToySerialController.{}.var'.format(version)
-zipPath = 'Custom\\Scripts\\Yoooi\\ToySerialController\\'
+zipPath = 'Custom/Scripts/Yoooi/ToySerialController/'
 
 print('Creating "{}"'.format(cslistName))
-with open('ADD_ME.cslist', 'w+', encoding='utf-8') as cslist:
+with open(cslistName, 'w+', encoding='utf-8') as cslist:
     for file in sorted(glob.glob('**/*.cs', recursive=True)):
         if not file.startswith('src') and not file.startswith('lib'):
             continue
@@ -25,7 +26,7 @@ print('Creating "{}"'.format(varName))
 with open(cslistName, 'r', encoding = 'utf-8') as cslist:
     with ZipFile(varName, 'w') as var:
         var.write('meta.json')
-        var.write('LICENSE')
+        var.write('LICENSE.md')
         var.write(cslistName, os.path.join(zipPath, cslistName))
         for file in [x.strip() for x in cslist]:
             var.write(file, os.path.join(zipPath, file))

--- a/src/Device/IDevice.cs
+++ b/src/Device/IDevice.cs
@@ -9,7 +9,7 @@ namespace ToySerialController
     public interface IDevice : IUIProvider, IConfigProvider, IDisposable
     {
         bool Update(IMotionSource motionSource);
-        void Write(SerialPort serial);
+        void Write(SerialWrapper serial);
 
         string GetDeviceReport();
     }

--- a/src/Device/SerialWrapper.cs
+++ b/src/Device/SerialWrapper.cs
@@ -1,0 +1,54 @@
+using DebugUtils;
+using System;
+using System.IO.Ports;
+
+namespace ToySerialController
+{
+    public class SerialWrapper
+    {
+        private SerialPort _serial;
+        public int ReadTimeout;
+        public int WriteTimeout;
+        public bool DtrEnable;
+        public bool RtsEnable;
+        
+        public SerialWrapper(string portName, int portSpeed=115200)
+        {
+            SuperController.LogMessage("SerialWrapper init " + portName + ":" + portSpeed);
+            if (portSpeed > 0)
+            {
+            _serial = new SerialPort(portName, portSpeed)
+                {
+                    ReadTimeout = ReadTimeout,
+                    WriteTimeout = WriteTimeout,
+                    DtrEnable = DtrEnable,
+                    RtsEnable = RtsEnable
+                };
+            }
+        }
+        
+        public virtual void Open()
+        {
+            SuperController.LogMessage("SerialWrapper Open()");
+            _serial.Open();
+        }
+        
+        public virtual void Close()
+        {
+            SuperController.LogMessage("SerialWrapper Close()");
+            _serial.Close();
+        }
+        
+        public virtual void Write(string data)
+        {
+            SuperController.LogMessage("SerialWrapper Write()");
+            _serial.Write(data);
+        }
+        
+        public virtual bool IsOpen()
+        {
+            SuperController.LogMessage("SerialWrapper IsOpen()");
+            return _serial.IsOpen;
+        }
+    }
+}

--- a/src/Device/TCodeDevice.cs
+++ b/src/Device/TCodeDevice.cs
@@ -1,5 +1,4 @@
 using DebugUtils;
-using System.IO.Ports;
 using System.Linq;
 using System.Text;
 using ToySerialController.MotionSource;
@@ -39,7 +38,7 @@ namespace ToySerialController
             _stringBuilder = new StringBuilder();
         }
 
-        public void Write(SerialPort serial)
+        public void Write(SerialWrapper serial)
         {
             _stringBuilder.Length = 0;
             var l0 = AppendIfChanged(_stringBuilder, "L0", XCmd[0], ref LastXCmd[0]);
@@ -53,7 +52,7 @@ namespace ToySerialController
             var l3 = AppendIfChanged(_stringBuilder, "L3", ECmd[2], ref LastECmd[2]);
 
             var data = $"{_stringBuilder}\n";
-            if (serial?.IsOpen == true && !string.IsNullOrEmpty(data.Trim()))
+            if (serial?.IsOpen() == true && !string.IsNullOrEmpty(data.Trim()))
                 serial.Write(data);
 
             _stringBuilder.Length = 0;

--- a/src/Device/UdpSerial.cs
+++ b/src/Device/UdpSerial.cs
@@ -1,0 +1,133 @@
+using DebugUtils;
+using System;
+using System.IO.Ports;
+using System.Text;
+using System.Net.Sockets;
+using System.Net;
+
+namespace ToySerialController
+{
+    public class UdpSerial : SerialWrapper
+    {
+        private string _udpAddress;
+        private string _udpPort;
+        public bool _isConnected;
+        private bool _isConnecting;
+        private UdpClient _udpClient;
+        
+        public UdpSerial(string address, string port) : base("", 0)
+        {
+            SuperController.LogMessage("UdpSerial init " + address + ":" + port);
+            _isConnected = false;
+            _isConnecting = false;
+            _udpAddress = address;
+            _udpPort = port;
+        }
+        
+        public override void Open()
+        {
+            SuperController.LogMessage("UdpSerial try open");
+            try
+            {
+                if (!_isConnected)
+                {
+                    setNetworkStatus(true);
+                    _isConnecting = true;
+                    IPEndPoint tcodeIPEndPoint = CreateIPEndPoint(_udpAddress + ":" + _udpPort);
+                    SuperController.LogMessage("UdpSerial new UDP");
+					_udpClient = new UdpClient();
+                    SuperController.LogMessage("UdpSerial connect");
+                    _udpClient.Connect(tcodeIPEndPoint);
+					var handshake = System.Text.Encoding.ASCII.GetBytes("D1\n");
+					//Log.Debug(DateTime.Now + " Sending udp connection handshake");
+                    SuperController.LogMessage("UdpSerial send handshake");
+					_udpClient.Send(handshake, handshake.Length);
+					_udpClient.BeginReceive(ReceiveCallback, new UdpState() {udp = _udpClient, ip = tcodeIPEndPoint});
+                }
+			}
+            catch (Exception e)
+            {
+                SuperController.LogError("UDP Exception: " + e);
+            }
+        }
+        
+        public override void Close()
+        {
+ 			_isConnecting = false;
+			_isConnected = false;
+			if(_udpClient != null)
+				_udpClient.Close();
+            SuperController.LogMessage("UDP connection stopped");           
+        }
+        
+        public override void Write(string tcode)
+        {
+			var tcodeBytes = System.Text.Encoding.ASCII.GetBytes(tcode);
+			_udpClient.Send(tcodeBytes, tcodeBytes.Length);
+        }
+        
+        public override bool IsOpen()
+        {
+            return _isConnected;
+        }
+    
+        private class UdpState {
+			public UdpClient udp;
+			public IPEndPoint ip;
+		}
+
+		private void ReceiveCallback(IAsyncResult ar)
+		{
+            try
+            {
+				UdpClient u = ((UdpState)(ar.AsyncState)).udp;
+				IPEndPoint e = ((UdpState)(ar.AsyncState)).ip;
+
+				byte[] receiveBytes = u.EndReceive(ar, ref e);
+				string receiveString = System.Text.Encoding.ASCII.GetString(receiveBytes);
+
+            	SuperController.LogMessage(receiveString);
+				if (receiveString.Contains("TCode"))
+				{
+					_isConnected = true;
+				}
+				_isConnecting = false;
+				setNetworkStatus();
+			}
+            catch (Exception e)
+            {
+                SuperController.LogError("UDP callback Exception: " + e);
+            }
+		}
+		private void setNetworkStatus(bool connecting = false) {
+        //    networkAddress.val = _defaultIPAddress + ":" + _defaultPort + "\n" + (connecting ? "Connecting..." : (_isConnected ? "Connected" : "Not connected"));
+		}
+		// Handles IPv4 and IPv6 notation.
+		public static IPEndPoint CreateIPEndPoint(string endPoint)
+		{
+			string[] ep = endPoint.Split(':');
+			if (ep.Length < 2) throw new FormatException("Invalid endpoint format");
+			IPAddress ip;
+			if (ep.Length > 2)
+			{
+				if (!IPAddress.TryParse(string.Join(":", ep, 0, ep.Length - 1), out ip))
+				{
+					throw new FormatException("Invalid ip-adress");
+				}
+			}
+			else
+			{
+				if (!IPAddress.TryParse(ep[0], out ip))
+				{
+					throw new FormatException("Invalid ip-adress");
+				}
+			}
+			int port;
+			if (!int.TryParse(ep[ep.Length - 1], System.Globalization.NumberStyles.None, System.Globalization.NumberFormatInfo.CurrentInfo, out port))
+			{
+				throw new FormatException("Invalid port");
+			}
+			return new IPEndPoint(ip, port);
+		}
+    }
+}

--- a/src/Plugin.UI.cs
+++ b/src/Plugin.UI.cs
@@ -15,7 +15,9 @@ namespace ToySerialController
 
         private UIDynamicButton PluginTitle, MotionSourceTitle, HardwareTitle;
         private JSONStorableStringChooser ComPortChooser;
-        private JSONStorableStringChooser MotionSourceChooser;
+        private JSONStorableString UdpAddress;
+        private JSONStorableString UdpPort;
+	private JSONStorableStringChooser MotionSourceChooser;
         private UIDynamicButton StartSerialButton, StopSerialButton;
         private JSONStorableString DeviceReportText;
         private JSONStorableBool DebugDrawEnableToggle;
@@ -60,7 +62,10 @@ namespace ToySerialController
             var visible = false;
             HardwareTitle = _group.CreateButton("Hardware", () => hardwareGroup.SetVisible(visible = !visible), new Color(0.3f, 0.3f, 0.3f), Color.white);
 
-            ComPortChooser = hardwareGroup.CreatePopup("Plugin:ComPortChooser", "Select COM port", SerialPort.GetPortNames().ToList(), "None", null);
+            var serialPortList = new List<string> (SerialPort.GetPortNames().ToList());
+            serialPortList.Add("UDP");
+            ComPortChooser = hardwareGroup.CreatePopup("Plugin:ComPortChooser", "Select COM port", serialPortList, "None", null);
+
 
             SerialButtonGroup = hardwareGroup.CreateHorizontalGroup(510, 50, new Vector2(10, 0), 2, idx => _group.CreateButtonEx());
             var startSerialButton = SerialButtonGroup.items[0].GetComponent<UIDynamicButton>();

--- a/src/Plugin.UI.cs
+++ b/src/Plugin.UI.cs
@@ -65,7 +65,8 @@ namespace ToySerialController
             var serialPortList = new List<string> (SerialPort.GetPortNames().ToList());
             serialPortList.Add("UDP");
             ComPortChooser = hardwareGroup.CreatePopup("Plugin:ComPortChooser", "Select COM port", serialPortList, "None", null);
-
+            UdpAddress = hardwareGroup.CreateTextField("Plugin:UdpAddress", UdpAddress?.ToString(), 0);
+            UdpPort = hardwareGroup.CreateTextField("Plugin:UdpPort", UdpPort?.ToString(), 0);
 
             SerialButtonGroup = hardwareGroup.CreateHorizontalGroup(510, 50, new Vector2(10, 0), 2, idx => _group.CreateButtonEx());
             var startSerialButton = SerialButtonGroup.items[0].GetComponent<UIDynamicButton>();

--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -106,9 +106,9 @@ namespace ToySerialController
             var portName = ComPortChooser.val;
             if (portName == "UDP")
             {
-                _serial = new UdpSerial(UdpAddress.ToString(), UdpPort.ToString());
+                _serial = new UdpSerial(UdpAddress.val, UdpPort.val);
                 _serial.Open();
-                SuperController.LogMessage($"UDP connection started: {UdpAddress}:{UdpPort}");
+                SuperController.LogMessage($"UDP connection started: {UdpAddress.val}:{UdpPort.val}");
             }
             else if (portName != "None")
             {


### PR DESCRIPTION
Implements a wrapper around serial access to allow use of UDP to talk to the toy. Config is done through the config file since I could not figure out how to do that in the UI. Select UDP as com port. Serial should still work.